### PR TITLE
mavros 0.15 fixes and catkin fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include(FindPkgConfig)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
     roscpp
+    mavros
+    mavros_msgs
     image_transport
     cv_bridge
 )

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The ros_erle_teleoperation package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="ahcorde@todo.todo">ahcorde</maintainer>
@@ -41,7 +41,18 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>mavros</build_depend>
+  <build_depend>mavros_msgs</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>cv_bridge</build_depend>
 
+  <run_depend>roscpp</run_depend>
+  <run_depend>mavros</run_depend>
+  <run_depend>mavros_msgs</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- You can specify that this package is a metapackage here: -->

--- a/src/ROS/mavros_setstreamrate.cpp
+++ b/src/ROS/mavros_setstreamrate.cpp
@@ -22,7 +22,7 @@ MAVROS_setStreamRate::MAVROS_setStreamRate()
     ros::ServiceClient cl = n.serviceClient<mavros_msgs::ParamSet>("/mavros/param/set");
     for(;;) {
         if (cl_get.call(paramget)) {
-            ROS_INFO("Send OK %d Value: %d", paramget.response.success, paramget.response.value.integer);
+            ROS_INFO("Send OK %d Value: %ld", paramget.response.success, paramget.response.value.integer);
             if (paramget.response.value.integer == 1) {
                 break;
             } else {

--- a/src/ROS/mavros_setstreamrate.cpp
+++ b/src/ROS/mavros_setstreamrate.cpp
@@ -3,39 +3,40 @@
 MAVROS_setStreamRate::MAVROS_setStreamRate()
 {
     ros::NodeHandle n;
-    ros::ServiceClient client = n.serviceClient<mavros::StreamRate>("/mavros/set_stream_rate");
-    mavros::StreamRate srv;
+    ros::ServiceClient client = n.serviceClient<mavros_msgs::StreamRate>("/mavros/set_stream_rate");
+    mavros_msgs::StreamRate srv;
     srv.request.stream_id = 0;
     srv.request.message_rate = 100;
     srv.request.on_off = 1;
-    if(client.call(srv)){
-        ROS_INFO("send ok");
-    }else{
+
+    if (client.call(srv)) {
+        ROS_INFO("Send OK");
+    } else {
         ROS_INFO("Failed to call service");
     }
 
-    ros::ServiceClient cl_get = n.serviceClient<mavros::ParamGet>("/mavros/param/get");
-    mavros::ParamGet paramget;
+    ros::ServiceClient cl_get = n.serviceClient<mavros_msgs::ParamGet>("/mavros/param/get");
+    mavros_msgs::ParamGet paramget;
     paramget.request.param_id = "SYSID_MYGCS";
 
-    ros::ServiceClient cl = n.serviceClient<mavros::ParamSet>("/mavros/param/set");
-    while(true){
-        if(cl_get.call(paramget)){
-            ROS_INFO("send ok %d value: %d", paramget.response.success, paramget.response.integer);
-            if(paramget.response.integer==1){
+    ros::ServiceClient cl = n.serviceClient<mavros_msgs::ParamSet>("/mavros/param/set");
+    for(;;) {
+        if (cl_get.call(paramget)) {
+            ROS_INFO("Send OK %d Value: %d", paramget.response.success, paramget.response.value.integer);
+            if (paramget.response.value.integer == 1) {
                 break;
-            }else{
-                mavros::ParamSet paramset2;
+            } else {
+                mavros_msgs::ParamSet paramset2;
                 paramset2.request.param_id = "SYSID_MYGCS";
-                paramset2.request.integer = 1;
-                paramset2.request.real = 1;
-                if(cl.call(paramset2)){
+                paramset2.request.value.integer = 1;
+                paramset2.request.value.real = 1;
+                if (cl.call(paramset2)) {
                     ROS_INFO("SYSIS_MYGCS: send ok");
-                }else{
+                } else {
                     ROS_INFO("Failed to call service SYSIS_MYGCS");
                 }
             }
-        }else{
+        } else {
             ROS_ERROR("Failed GET PARAMETER");
         }
     }

--- a/src/ROS/mavros_setstreamrate.h
+++ b/src/ROS/mavros_setstreamrate.h
@@ -2,9 +2,9 @@
 #define MAVROS_SETSTREAMRATE_H
 
 #include <ros/ros.h>
-#include "mavros/StreamRate.h"
-#include "mavros/ParamSet.h"
-#include "mavros/ParamGet.h"
+#include "mavros_msgs/StreamRate.h"
+#include "mavros_msgs/ParamSet.h"
+#include "mavros_msgs/ParamGet.h"
 
 class MAVROS_setStreamRate
 {

--- a/src/ROS/mavros_setstreamrate.h
+++ b/src/ROS/mavros_setstreamrate.h
@@ -2,9 +2,9 @@
 #define MAVROS_SETSTREAMRATE_H
 
 #include <ros/ros.h>
-#include <mavros/StreamRate.h>
-#include <mavros/ParamSet.h>
-#include <mavros/ParamGet.h>
+#include "mavros/StreamRate.h"
+#include "mavros/ParamSet.h"
+#include "mavros/ParamGet.h"
 
 class MAVROS_setStreamRate
 {

--- a/src/ROS/subscribe_mavros_state.cpp
+++ b/src/ROS/subscribe_mavros_state.cpp
@@ -5,7 +5,7 @@ Subscribe_mavros_state::Subscribe_mavros_state(Shared_Memory* shared_memory)
     this->shared_memory = shared_memory;
 }
 
-void Subscribe_mavros_state::mavrosStateCb(const mavros::StateConstPtr &msg)
+void Subscribe_mavros_state::mavrosStateCb(const mavros_msgs::StateConstPtr &msg)
 {
     if(msg->mode == std::string("CMODE(0)"))
         return;

--- a/src/ROS/subscribe_mavros_state.h
+++ b/src/ROS/subscribe_mavros_state.h
@@ -2,7 +2,7 @@
 #define SUBSCRIBE_MAVROS_STATE_H
 
 #include <ros/ros.h>
-#include <mavros/State.h>
+#include "mavros/State.h"
 
 #include "../shared_memory.h"
 

--- a/src/ROS/subscribe_mavros_state.h
+++ b/src/ROS/subscribe_mavros_state.h
@@ -2,7 +2,7 @@
 #define SUBSCRIBE_MAVROS_STATE_H
 
 #include <ros/ros.h>
-#include "mavros/State.h"
+#include "mavros_msgs/State.h"
 
 #include "../shared_memory.h"
 

--- a/src/ROS/subscribe_mavros_state.h
+++ b/src/ROS/subscribe_mavros_state.h
@@ -10,7 +10,7 @@ class Subscribe_mavros_state
 {
 public:
     Subscribe_mavros_state(Shared_Memory* shared_memory);
-    void mavrosStateCb(const mavros::StateConstPtr &msg);
+    void mavrosStateCb(const mavros_msgs::StateConstPtr &msg);
 
 private:
     Shared_Memory* shared_memory;

--- a/src/ROS/thread_ros.cpp
+++ b/src/ROS/thread_ros.cpp
@@ -5,9 +5,9 @@ Thread_ROS::Thread_ROS(Shared_Memory* share_memory)
     this->share_memory = share_memory;
 
     ros::NodeHandle n;
-    rc_override_pub = n.advertise< mavros::OverrideRCIn >("/mavros/rc/override", 10);
-    cl_param = n.serviceClient<mavros::ParamGet>("/mavros/param/get");
-    cl_mode = n.serviceClient<mavros::SetMode>("/mavros/set_mode");
+    rc_override_pub = n.advertise< mavros_msgs::OverrideRCIn >("/mavros/rc/override", 10);
+    cl_param = n.serviceClient<mavros_msgs::ParamGet>("/mavros/param/get");
+    cl_mode = n.serviceClient<mavros_msgs::SetMode>("/mavros/set_mode");
 
     std::vector<int> rc_maxlimtis;
     std::vector<int> rc_minlimtis;
@@ -31,7 +31,7 @@ Thread_ROS::Thread_ROS(Shared_Memory* share_memory)
 Thread_ROS::~Thread_ROS()
 {
     stop = true;
-    mavros::OverrideRCIn msg_override;
+    mavros_msgs::OverrideRCIn msg_override;
 
     for(int i = 0; i < 8; i++){
         msg_override.channels[i] = 0;
@@ -49,37 +49,36 @@ Thread_ROS::~Thread_ROS()
 
 int Thread_ROS::RC_Param(std::string s, int i)
 {
-    mavros::ParamGet srv;
+    mavros_msgs::ParamGet srv;
     std::stringstream ss;
     ss << (i+1);
     std::string param = std::string("RC") + ss.str() + s;
     srv.request.param_id = param;
-    if(cl_param.call(srv)){
-        ROS_INFO("send ok %d value: %d", srv.response.success, srv.response.integer);
-        if(srv.response.success)
-            return srv.response.integer;
-        else
-            return -1;
-    }else{
-        ROS_ERROR("Failed RC_PARAM");
+    if (cl_param.call(srv)) {
+        ROS_INFO("Send OK %d Value: %d", srv.response.success, srv.response.value.integer);
+        if (srv.response.success)
+            return srv.response.value.integer;
         return -1;
+    }
+
+    ROS_ERROR("Failed RC_PARAM");
+    return -1;
     }
 }
 
 void Thread_ROS::updateMode()
 {
     if(share_memory->getMode()!=share_memory->getModeChange() && !share_memory->getModeChange().empty()){
-        mavros::SetMode srv;
+        mavros_msgs::SetMode srv;
         srv.request.base_mode = 0;
         srv.request.custom_mode = share_memory->getModeChange();
-        if(cl_mode.call(srv)){
-            ROS_INFO("send ok %d value:", srv.response.success);
-        }else{
+        if (cl_mode.call(srv)) {
+            ROS_INFO("Send OK %d Value:", srv.response.success);
+        } else {
             ROS_ERROR("Failed SetMode");
             return;
         }
     }
-
 }
 
 void Thread_ROS::run()
@@ -97,7 +96,7 @@ void Thread_ROS::run()
 
         updateMode();
 
-        mavros::OverrideRCIn msg_override;
+        mavros_msgs::OverrideRCIn msg_override;
 
         if(share_memory->getOverride()){
             msg_override.channels[0] = share_memory->getRoll();

--- a/src/ROS/thread_ros.cpp
+++ b/src/ROS/thread_ros.cpp
@@ -55,7 +55,7 @@ int Thread_ROS::RC_Param(std::string s, int i)
     std::string param = std::string("RC") + ss.str() + s;
     srv.request.param_id = param;
     if (cl_param.call(srv)) {
-        ROS_INFO("Send OK %d Value: %d", srv.response.success, srv.response.value.integer);
+        ROS_INFO("Send OK %d Value: %ld", srv.response.success, srv.response.value.integer);
         if (srv.response.success)
             return srv.response.value.integer;
         return -1;
@@ -63,7 +63,7 @@ int Thread_ROS::RC_Param(std::string s, int i)
 
     ROS_ERROR("Failed RC_PARAM");
     return -1;
-    }
+    
 }
 
 void Thread_ROS::updateMode()

--- a/src/ROS/thread_ros.h
+++ b/src/ROS/thread_ros.h
@@ -7,9 +7,9 @@
 
 #include <ros/ros.h>
 #include "../shared_memory.h"
-#include <mavros/OverrideRCIn.h>
-#include <mavros/ParamGet.h>
-#include <mavros/SetMode.h>
+#include "mavros/OverrideRCIn.h"
+#include "mavros/ParamGet.h"
+#include "mavros/SetMode.h"
 
 class Thread_ROS:public QThread
 {

--- a/src/ROS/thread_ros.h
+++ b/src/ROS/thread_ros.h
@@ -7,9 +7,9 @@
 
 #include <ros/ros.h>
 #include "../shared_memory.h"
-#include "mavros/OverrideRCIn.h"
-#include "mavros/ParamGet.h"
-#include "mavros/SetMode.h"
+#include "mavros_msgs/OverrideRCIn.h"
+#include "mavros_msgs/ParamGet.h"
+#include "mavros_msgs/SetMode.h"
 
 class Thread_ROS:public QThread
 {


### PR DESCRIPTION
I changed the namespace to get it working with mavros 0.15. The `package.xml` and `CMakeLists.txt` are also fixed to get it build using catkin. 

These fixes are done on a system running **ROS Indigo**
